### PR TITLE
feat: Add task scheduler

### DIFF
--- a/.sqlx/query-22204faeb1a4f6576d50f011fff343b0f71920fab315323e56ccccefda04317d.json
+++ b/.sqlx/query-22204faeb1a4f6576d50f011fff343b0f71920fab315323e56ccccefda04317d.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at\n                    FROM scheduled_jobs\n                    WHERE telegram_chat_id = $1 AND message_thread_id = $2\n                    ORDER BY name ASC\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "cron_schedule",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "prompt",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "telegram_chat_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "message_thread_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "22204faeb1a4f6576d50f011fff343b0f71920fab315323e56ccccefda04317d"
+}

--- a/.sqlx/query-6aa469feb5e919c0d27ea290fadb4f5df249e005e95fe9d9c602d03f1979d034.json
+++ b/.sqlx/query-6aa469feb5e919c0d27ea290fadb4f5df249e005e95fe9d9c602d03f1979d034.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE scheduled_jobs\n                    SET enabled = $1, updated_at = NOW()\n                    WHERE name = $2 AND telegram_chat_id = $3 AND message_thread_id = $4\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6aa469feb5e919c0d27ea290fadb4f5df249e005e95fe9d9c602d03f1979d034"
+}

--- a/.sqlx/query-8db338959b27fcb04153f378ae962d118c689157158675688ecb2b775f97ef00.json
+++ b/.sqlx/query-8db338959b27fcb04153f378ae962d118c689157158675688ecb2b775f97ef00.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    DELETE FROM scheduled_jobs\n                    WHERE name = $1 AND telegram_chat_id = $2 AND message_thread_id = $3\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8db338959b27fcb04153f378ae962d118c689157158675688ecb2b775f97ef00"
+}

--- a/.sqlx/query-8e00c0a156ce87fe72bbd158df3afdc1204680e7f7618735171370aa467e06b5.json
+++ b/.sqlx/query-8e00c0a156ce87fe72bbd158df3afdc1204680e7f7618735171370aa467e06b5.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    DELETE FROM scheduled_jobs\n                    WHERE name = $1 AND telegram_chat_id = $2 AND message_thread_id IS NULL\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8e00c0a156ce87fe72bbd158df3afdc1204680e7f7618735171370aa467e06b5"
+}

--- a/.sqlx/query-c78992b9f6b8b8fc546b4b9c3e909cd8d8bbf0fc398f7e22d9a57a7e5820723a.json
+++ b/.sqlx/query-c78992b9f6b8b8fc546b4b9c3e909cd8d8bbf0fc398f7e22d9a57a7e5820723a.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at\n            FROM scheduled_jobs\n            WHERE enabled = true\n            ORDER BY id ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "cron_schedule",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "prompt",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "telegram_chat_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "message_thread_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c78992b9f6b8b8fc546b4b9c3e909cd8d8bbf0fc398f7e22d9a57a7e5820723a"
+}

--- a/.sqlx/query-d5bad662d81592366f278fe0bfc6df1781dbe890901e28ef3d26efb2b0717335.json
+++ b/.sqlx/query-d5bad662d81592366f278fe0bfc6df1781dbe890901e28ef3d26efb2b0717335.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at\n                    FROM scheduled_jobs\n                    WHERE telegram_chat_id = $1 AND message_thread_id IS NULL\n                    ORDER BY name ASC\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "cron_schedule",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "prompt",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "telegram_chat_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "message_thread_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d5bad662d81592366f278fe0bfc6df1781dbe890901e28ef3d26efb2b0717335"
+}

--- a/.sqlx/query-e4f5a275420703a9e486e41204d7954795e5d2f37e2a3d1f6a95b57c93daa8d5.json
+++ b/.sqlx/query-e4f5a275420703a9e486e41204d7954795e5d2f37e2a3d1f6a95b57c93daa8d5.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE scheduled_jobs\n                    SET enabled = $1, updated_at = NOW()\n                    WHERE name = $2 AND telegram_chat_id = $3 AND message_thread_id IS NULL\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e4f5a275420703a9e486e41204d7954795e5d2f37e2a3d1f6a95b57c93daa8d5"
+}

--- a/.sqlx/query-f246e0904b621595d15b15eee229b3478c54044ee35f15dd9f3f341af68617bc.json
+++ b/.sqlx/query-f246e0904b621595d15b15eee229b3478c54044ee35f15dd9f3f341af68617bc.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scheduled_jobs (name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at)\n            VALUES ($1, $2, $3, $4, $5, true, NOW(), NOW())\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f246e0904b621595d15b15eee229b3478c54044ee35f15dd9f3f341af68617bc"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "croner"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1149,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "croner",
  "dotenv",
  "futures",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sqlx = { version = "0.8.6", features = [
     "bigdecimal",
 ] }
 tokio = { version = "1.46.1", features = ["full"] }
+croner = "2.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = [
     "env-filter",

--- a/migrations/20260119120000_add_scheduled_jobs.sql
+++ b/migrations/20260119120000_add_scheduled_jobs.sql
@@ -1,0 +1,15 @@
+-- Scheduled jobs table for cron-based task execution
+CREATE TABLE scheduled_jobs (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    cron_schedule TEXT NOT NULL,          -- e.g., "0 9 * * 1-5" (9am weekdays)
+    prompt TEXT NOT NULL,                  -- The prompt to send to OpenAI
+    telegram_chat_id BIGINT NOT NULL,      -- Target chat
+    message_thread_id BIGINT,              -- Optional: target topic/thread
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for efficient enabled job lookup
+CREATE INDEX idx_scheduled_jobs_enabled ON scheduled_jobs(enabled) WHERE enabled = true;

--- a/src/ai_interaction/mod.rs
+++ b/src/ai_interaction/mod.rs
@@ -111,6 +111,9 @@ pub struct HandlerContext<D: Db, B: BeaconNode> {
     pub beacon_node: B,
     pub relay_circuit_breaker: RelayCircuitBreaker,
     pub schema_fetcher: LiveSchemaFetcher,
+    // Chat context for tools that need to know which chat they're operating in
+    pub current_telegram_chat_id: Option<i64>,
+    pub current_message_thread_id: Option<i64>,
 }
 
 #[instrument(skip(ctx, prompt_text, previous_response_id))]

--- a/src/ai_interaction/openai_chat.rs
+++ b/src/ai_interaction/openai_chat.rs
@@ -42,6 +42,7 @@ pub static OPENAI_CALL_CONFIG: LazyLock<OpenAiCallConfig> = LazyLock::new(|| {
         ApiToolType::Function(tools::retrieve_manual::RETRIEVE_MANUAL_TOOL.clone()),
         ApiToolType::Function(tools::relay_circuit_breaker::RELAY_CIRCUIT_BREAKER_TOOL.clone()),
         ApiToolType::Function(tools::conversation_admin::CONVERSATION_ADMIN_TOOL.clone()),
+        ApiToolType::Function(tools::scheduled_jobs::SCHEDULED_JOBS_TOOL.clone()),
         ApiToolType::WebSearch(WebSearchToolConfig::new()),
     ];
     let instructions = indoc! {"
@@ -131,6 +132,14 @@ async fn execute_tool_call<D: Db, B: BeaconNode>(
     } else if tool_name == relay_circuit_breaker::RELAY_CIRCUIT_BREAKER_TOOL_NAME {
         relay_circuit_breaker::execute_relay_circuit_breaker_tool(
             &ctx.relay_circuit_breaker,
+            arguments,
+        )
+        .await
+    } else if tool_name == scheduled_jobs::SCHEDULED_JOBS_TOOL_NAME {
+        scheduled_jobs::execute_scheduled_jobs(
+            &ctx.db,
+            ctx.current_telegram_chat_id,
+            ctx.current_message_thread_id,
             arguments,
         )
         .await

--- a/src/ai_interaction/tools/mod.rs
+++ b/src/ai_interaction/tools/mod.rs
@@ -5,6 +5,7 @@ pub mod db_query;
 pub mod db_schema;
 pub mod relay_circuit_breaker;
 pub mod retrieve_manual;
+pub mod scheduled_jobs;
 
 use crate::openai_api::ApiToolType;
 

--- a/src/ai_interaction/tools/scheduled_jobs.rs
+++ b/src/ai_interaction/tools/scheduled_jobs.rs
@@ -1,0 +1,607 @@
+use crate::db::Db;
+use crate::openai_api::{
+    ToolDefinition, ToolFunctionParameterPropertyBuilder, ToolFunctionParameters,
+};
+use anyhow::Result;
+use serde_json::{json, Value as JsonValue};
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use tracing::{info, instrument, warn};
+
+pub const SCHEDULED_JOBS_TOOL_NAME: &str = "scheduled_jobs";
+
+// Command names
+const LIST_COMMAND: &str = "list";
+const ADD_COMMAND: &str = "add";
+const DELETE_COMMAND: &str = "delete";
+const ENABLE_COMMAND: &str = "enable";
+const DISABLE_COMMAND: &str = "disable";
+
+// Parameter names
+const COMMAND_PARAM: &str = "command";
+const NAME_PARAM: &str = "name";
+const CRON_SCHEDULE_PARAM: &str = "cron_schedule";
+const PROMPT_PARAM: &str = "prompt";
+
+pub static SCHEDULED_JOBS_TOOL: LazyLock<ToolDefinition> = LazyLock::new(|| {
+    let mut params_props = HashMap::new();
+
+    params_props.insert(
+        COMMAND_PARAM.to_string(),
+        ToolFunctionParameterPropertyBuilder::new_string()
+            .description(
+                "The operation to perform: 'list' to show all scheduled jobs, 'add' to create a new job, 'delete' to remove a job, 'enable' or 'disable' to toggle a job's active status.",
+            )
+            .enum_string(&[LIST_COMMAND, ADD_COMMAND, DELETE_COMMAND, ENABLE_COMMAND, DISABLE_COMMAND])
+            .build(),
+    );
+
+    params_props.insert(
+        NAME_PARAM.to_string(),
+        ToolFunctionParameterPropertyBuilder::new_string()
+            .description(
+                "The unique name for the scheduled job. Required for add/delete/enable/disable commands.",
+            )
+            .build(),
+    );
+
+    params_props.insert(
+        CRON_SCHEDULE_PARAM.to_string(),
+        ToolFunctionParameterPropertyBuilder::new_string()
+            .description(
+                "Cron schedule expression (e.g., '0 9 * * *' for daily at 9am UTC, '*/5 * * * *' for every 5 minutes). Required for add command.",
+            )
+            .build(),
+    );
+
+    params_props.insert(
+        PROMPT_PARAM.to_string(),
+        ToolFunctionParameterPropertyBuilder::new_string()
+            .description(
+                "The prompt to send to the AI when the scheduled job runs. Required for add command.",
+            )
+            .build(),
+    );
+
+    let tool_params = ToolFunctionParameters {
+        r#type: "object".to_string(),
+        properties: params_props,
+        required: Some(vec![COMMAND_PARAM.to_string()]),
+        additional_properties: false,
+    };
+
+    ToolDefinition::new(
+        SCHEDULED_JOBS_TOOL_NAME.to_string(),
+        Some(
+            "Manages scheduled jobs for this chat. Jobs run on a cron schedule and send the specified prompt to the AI, with the response sent back to this chat."
+                .to_string(),
+        ),
+        Some(tool_params),
+    )
+});
+
+#[instrument(skip(db, arguments_json_str))]
+pub async fn execute_scheduled_jobs<D: Db>(
+    db: &D,
+    telegram_chat_id: Option<i64>,
+    message_thread_id: Option<i64>,
+    arguments_json_str: &str,
+) -> Result<String> {
+    info!(args = %arguments_json_str, "executing scheduled_jobs tool");
+
+    // Validate we have chat context
+    let chat_id = match telegram_chat_id {
+        Some(id) => id,
+        None => {
+            let err_msg = "cannot manage scheduled jobs: no chat context available";
+            warn!(args = %arguments_json_str, error = %err_msg);
+            return Ok(json!({
+                "status": "error",
+                "message": err_msg
+            })
+            .to_string());
+        }
+    };
+
+    // Parse arguments
+    let args: JsonValue = match serde_json::from_str(arguments_json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            let err_msg = format!("failed to parse arguments JSON: {e}");
+            warn!(args = %arguments_json_str, error = %err_msg);
+            return Ok(json!({
+                "status": "error",
+                "message": "malformed_json",
+                "details": err_msg
+            })
+            .to_string());
+        }
+    };
+
+    let command = args
+        .get(COMMAND_PARAM)
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    match command {
+        LIST_COMMAND => execute_list(db, chat_id, message_thread_id).await,
+        ADD_COMMAND => execute_add(db, chat_id, message_thread_id, &args).await,
+        DELETE_COMMAND => execute_delete(db, chat_id, message_thread_id, &args).await,
+        ENABLE_COMMAND => execute_set_enabled(db, chat_id, message_thread_id, &args, true).await,
+        DISABLE_COMMAND => execute_set_enabled(db, chat_id, message_thread_id, &args, false).await,
+        _ => {
+            let err_msg = format!("unknown command: '{command}'");
+            warn!(args = %arguments_json_str, error = %err_msg);
+            Ok(json!({
+                "status": "error",
+                "message": "unknown_command",
+                "details": err_msg
+            })
+            .to_string())
+        }
+    }
+}
+
+async fn execute_list<D: Db>(
+    db: &D,
+    telegram_chat_id: i64,
+    message_thread_id: Option<i64>,
+) -> Result<String> {
+    match db
+        .get_scheduled_jobs_for_chat(telegram_chat_id, message_thread_id)
+        .await
+    {
+        Ok(jobs) => {
+            let jobs_info: Vec<JsonValue> = jobs
+                .iter()
+                .map(|j| {
+                    json!({
+                        "name": j.name,
+                        "cron_schedule": j.cron_schedule,
+                        "prompt": j.prompt,
+                        "enabled": j.enabled
+                    })
+                })
+                .collect();
+
+            Ok(json!({
+                "status": "success",
+                "jobs": jobs_info,
+                "count": jobs.len()
+            })
+            .to_string())
+        }
+        Err(e) => {
+            let err_msg = format!("failed to fetch scheduled jobs: {e}");
+            warn!(error = %err_msg);
+            Ok(json!({
+                "status": "error",
+                "message": "database_error",
+                "details": err_msg
+            })
+            .to_string())
+        }
+    }
+}
+
+async fn execute_add<D: Db>(
+    db: &D,
+    telegram_chat_id: i64,
+    message_thread_id: Option<i64>,
+    args: &JsonValue,
+) -> Result<String> {
+    let name = match args.get(NAME_PARAM).and_then(|v| v.as_str()) {
+        Some(n) if !n.is_empty() => n,
+        _ => {
+            return Ok(json!({
+                "status": "error",
+                "message": "missing_parameter",
+                "details": format!("'{}' is required for add command", NAME_PARAM)
+            })
+            .to_string());
+        }
+    };
+
+    let cron_schedule = match args.get(CRON_SCHEDULE_PARAM).and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            return Ok(json!({
+                "status": "error",
+                "message": "missing_parameter",
+                "details": format!("'{}' is required for add command", CRON_SCHEDULE_PARAM)
+            })
+            .to_string());
+        }
+    };
+
+    let prompt = match args.get(PROMPT_PARAM).and_then(|v| v.as_str()) {
+        Some(p) if !p.is_empty() => p,
+        _ => {
+            return Ok(json!({
+                "status": "error",
+                "message": "missing_parameter",
+                "details": format!("'{}' is required for add command", PROMPT_PARAM)
+            })
+            .to_string());
+        }
+    };
+
+    // Validate cron schedule
+    if let Err(e) = croner::Cron::new(cron_schedule).parse() {
+        return Ok(json!({
+            "status": "error",
+            "message": "invalid_cron_schedule",
+            "details": format!("Invalid cron expression '{}': {}", cron_schedule, e)
+        })
+        .to_string());
+    }
+
+    match db
+        .create_scheduled_job(
+            name,
+            cron_schedule,
+            prompt,
+            telegram_chat_id,
+            message_thread_id,
+        )
+        .await
+    {
+        Ok(job_id) => {
+            info!(job_id = job_id, name = %name, cron = %cron_schedule, "created scheduled job");
+            Ok(json!({
+                "status": "success",
+                "message": format!("Created scheduled job '{}' with schedule '{}'", name, cron_schedule),
+                "job_id": job_id
+            })
+            .to_string())
+        }
+        Err(e) => {
+            let err_msg = format!("failed to create scheduled job: {e}");
+            warn!(error = %err_msg);
+            Ok(json!({
+                "status": "error",
+                "message": "database_error",
+                "details": err_msg
+            })
+            .to_string())
+        }
+    }
+}
+
+async fn execute_delete<D: Db>(
+    db: &D,
+    telegram_chat_id: i64,
+    message_thread_id: Option<i64>,
+    args: &JsonValue,
+) -> Result<String> {
+    let name = match args.get(NAME_PARAM).and_then(|v| v.as_str()) {
+        Some(n) if !n.is_empty() => n,
+        _ => {
+            return Ok(json!({
+                "status": "error",
+                "message": "missing_parameter",
+                "details": format!("'{}' is required for delete command", NAME_PARAM)
+            })
+            .to_string());
+        }
+    };
+
+    match db
+        .delete_scheduled_job_by_name(name, telegram_chat_id, message_thread_id)
+        .await
+    {
+        Ok(deleted) => {
+            if deleted {
+                info!(name = %name, "deleted scheduled job");
+                Ok(json!({
+                    "status": "success",
+                    "message": format!("Deleted scheduled job '{}'", name)
+                })
+                .to_string())
+            } else {
+                Ok(json!({
+                    "status": "error",
+                    "message": "not_found",
+                    "details": format!("No scheduled job named '{}' found in this chat", name)
+                })
+                .to_string())
+            }
+        }
+        Err(e) => {
+            let err_msg = format!("failed to delete scheduled job: {e}");
+            warn!(error = %err_msg);
+            Ok(json!({
+                "status": "error",
+                "message": "database_error",
+                "details": err_msg
+            })
+            .to_string())
+        }
+    }
+}
+
+async fn execute_set_enabled<D: Db>(
+    db: &D,
+    telegram_chat_id: i64,
+    message_thread_id: Option<i64>,
+    args: &JsonValue,
+    enabled: bool,
+) -> Result<String> {
+    let name = match args.get(NAME_PARAM).and_then(|v| v.as_str()) {
+        Some(n) if !n.is_empty() => n,
+        _ => {
+            let action = if enabled { "enable" } else { "disable" };
+            return Ok(json!({
+                "status": "error",
+                "message": "missing_parameter",
+                "details": format!("'{}' is required for {} command", NAME_PARAM, action)
+            })
+            .to_string());
+        }
+    };
+
+    match db
+        .set_scheduled_job_enabled(name, telegram_chat_id, message_thread_id, enabled)
+        .await
+    {
+        Ok(updated) => {
+            if updated {
+                let action = if enabled { "enabled" } else { "disabled" };
+                info!(name = %name, enabled = enabled, "updated scheduled job enabled status");
+                Ok(json!({
+                    "status": "success",
+                    "message": format!("Scheduled job '{}' has been {}", name, action)
+                })
+                .to_string())
+            } else {
+                Ok(json!({
+                    "status": "error",
+                    "message": "not_found",
+                    "details": format!("No scheduled job named '{}' found in this chat", name)
+                })
+                .to_string())
+            }
+        }
+        Err(e) => {
+            let err_msg = format!("failed to update scheduled job: {e}");
+            warn!(error = %err_msg);
+            Ok(json!({
+                "status": "error",
+                "message": "database_error",
+                "details": err_msg
+            })
+            .to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::MockDb;
+    use crate::scheduler::types::ScheduledJob;
+    use chrono::Utc;
+    use mockall::predicate::*;
+
+    fn make_test_job(name: &str, enabled: bool) -> ScheduledJob {
+        ScheduledJob {
+            id: 1,
+            name: name.to_string(),
+            cron_schedule: "0 9 * * *".to_string(),
+            prompt: "Test prompt".to_string(),
+            telegram_chat_id: 123,
+            message_thread_id: None,
+            enabled,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_jobs_success() {
+        let mut mock_db = MockDb::new();
+        mock_db
+            .expect_get_scheduled_jobs_for_chat()
+            .with(eq(123i64), eq(None::<i64>))
+            .returning(|_, _| Ok(vec![make_test_job("daily_check", true)]));
+
+        let result = execute_scheduled_jobs(&mock_db, Some(123), None, r#"{"command": "list"}"#)
+            .await
+            .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "success");
+        assert_eq!(parsed["count"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_add_job_success() {
+        let mut mock_db = MockDb::new();
+        mock_db
+            .expect_create_scheduled_job()
+            .with(
+                eq("test_job"),
+                eq("0 9 * * *"),
+                eq("Check status"),
+                eq(123i64),
+                eq(None::<i64>),
+            )
+            .returning(|_, _, _, _, _| Ok(1));
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            Some(123),
+            None,
+            r#"{"command": "add", "name": "test_job", "cron_schedule": "0 9 * * *", "prompt": "Check status"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "success");
+    }
+
+    #[tokio::test]
+    async fn test_add_job_invalid_cron() {
+        let mock_db = MockDb::new();
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            Some(123),
+            None,
+            r#"{"command": "add", "name": "test_job", "cron_schedule": "invalid", "prompt": "Check status"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "error");
+        assert_eq!(parsed["message"], "invalid_cron_schedule");
+    }
+
+    #[tokio::test]
+    async fn test_add_job_missing_name() {
+        let mock_db = MockDb::new();
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            Some(123),
+            None,
+            r#"{"command": "add", "cron_schedule": "0 9 * * *", "prompt": "Check status"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "error");
+        assert_eq!(parsed["message"], "missing_parameter");
+    }
+
+    #[tokio::test]
+    async fn test_delete_job_success() {
+        let mut mock_db = MockDb::new();
+        mock_db
+            .expect_delete_scheduled_job_by_name()
+            .with(eq("test_job"), eq(123i64), eq(None::<i64>))
+            .returning(|_, _, _| Ok(true));
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            Some(123),
+            None,
+            r#"{"command": "delete", "name": "test_job"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "success");
+    }
+
+    #[tokio::test]
+    async fn test_delete_job_not_found() {
+        let mut mock_db = MockDb::new();
+        mock_db
+            .expect_delete_scheduled_job_by_name()
+            .with(eq("nonexistent"), eq(123i64), eq(None::<i64>))
+            .returning(|_, _, _| Ok(false));
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            Some(123),
+            None,
+            r#"{"command": "delete", "name": "nonexistent"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "error");
+        assert_eq!(parsed["message"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn test_enable_job_success() {
+        let mut mock_db = MockDb::new();
+        mock_db
+            .expect_set_scheduled_job_enabled()
+            .with(eq("test_job"), eq(123i64), eq(None::<i64>), eq(true))
+            .returning(|_, _, _, _| Ok(true));
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            Some(123),
+            None,
+            r#"{"command": "enable", "name": "test_job"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "success");
+    }
+
+    #[tokio::test]
+    async fn test_disable_job_success() {
+        let mut mock_db = MockDb::new();
+        mock_db
+            .expect_set_scheduled_job_enabled()
+            .with(eq("test_job"), eq(123i64), eq(None::<i64>), eq(false))
+            .returning(|_, _, _, _| Ok(true));
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            Some(123),
+            None,
+            r#"{"command": "disable", "name": "test_job"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "success");
+    }
+
+    #[tokio::test]
+    async fn test_no_chat_context() {
+        let mock_db = MockDb::new();
+
+        let result = execute_scheduled_jobs(
+            &mock_db,
+            None, // No chat context
+            None,
+            r#"{"command": "list"}"#,
+        )
+        .await
+        .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "error");
+    }
+
+    #[tokio::test]
+    async fn test_malformed_json() {
+        let mock_db = MockDb::new();
+
+        let result = execute_scheduled_jobs(&mock_db, Some(123), None, r#"not valid json"#)
+            .await
+            .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "error");
+        assert_eq!(parsed["message"], "malformed_json");
+    }
+
+    #[tokio::test]
+    async fn test_unknown_command() {
+        let mock_db = MockDb::new();
+
+        let result = execute_scheduled_jobs(&mock_db, Some(123), None, r#"{"command": "unknown"}"#)
+            .await
+            .unwrap();
+
+        let parsed: JsonValue = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["status"], "error");
+        assert_eq!(parsed["message"], "unknown_command");
+    }
+}

--- a/src/bin/chat_cli.rs
+++ b/src/bin/chat_cli.rs
@@ -90,6 +90,8 @@ async fn main() -> Result<()> {
         beacon_node,
         relay_circuit_breaker,
         schema_fetcher,
+        current_telegram_chat_id: None, // CLI doesn't have a chat context
+        current_message_thread_id: None,
     };
 
     info!(

--- a/src/bin/run_tg_bot.rs
+++ b/src/bin/run_tg_bot.rs
@@ -24,6 +24,7 @@ use lexi::bot::r#loop::{run_bot_loop, TELEGRAM_API_URL};
 use lexi::db::{self, Db};
 use lexi::env::ENV_CONFIG;
 use lexi::log;
+use lexi::scheduler::{service::run_scheduler, SchedulerContext};
 use lexi::telegram;
 
 #[tokio::main]
@@ -143,6 +144,14 @@ async fn main() -> Result<()> {
         beacon_node,
         relay_circuit_breaker,
     };
+
+    // Spawn the scheduler service in the background
+    let scheduler_ctx = SchedulerContext::from_bot_context(&bot_ctx);
+    tokio::spawn(async move {
+        if let Err(e) = run_scheduler(scheduler_ctx).await {
+            tracing::error!(error = %e, "scheduler service failed");
+        }
+    });
 
     run_bot_loop(bot_ctx).await
 }

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -493,6 +493,8 @@ pub async fn handle_telegram_update<D: Db + Clone>(
                     beacon_node: ctx.beacon_node.clone(),
                     relay_circuit_breaker: ctx.relay_circuit_breaker.clone(),
                     schema_fetcher: ctx.schema_fetcher.clone(),
+                    current_telegram_chat_id: Some(incoming_message.chat.id),
+                    current_message_thread_id: message_thread_id,
                 };
 
                 match ai_interaction::drive_ai_conversation(

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,6 +6,7 @@ use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
 use std::str::FromStr;
 
 use crate::key_value_store::{KeyValueStore, PostgresKeyValueStore};
+use crate::scheduler::types::ScheduledJob;
 use crate::telegram::types::{
     Chat as TelegramChat, Message as TelegramMessage, User as TelegramUser,
 };
@@ -54,6 +55,33 @@ pub trait Db {
         since: DateTime<Utc>,
         limit: i64,
     ) -> Result<Vec<MessageWithSender>>;
+    async fn get_enabled_scheduled_jobs(&self) -> Result<Vec<ScheduledJob>>;
+    async fn get_scheduled_jobs_for_chat(
+        &self,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+    ) -> Result<Vec<ScheduledJob>>;
+    async fn create_scheduled_job(
+        &self,
+        name: &str,
+        cron_schedule: &str,
+        prompt: &str,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+    ) -> Result<i32>;
+    async fn delete_scheduled_job_by_name(
+        &self,
+        name: &str,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+    ) -> Result<bool>;
+    async fn set_scheduled_job_enabled(
+        &self,
+        name: &str,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+        enabled: bool,
+    ) -> Result<bool>;
 }
 
 #[derive(Debug, Clone)]
@@ -419,6 +447,174 @@ impl Db for PostgresDb {
         };
 
         Ok(messages)
+    }
+
+    /// Fetches all enabled scheduled jobs from the database.
+    async fn get_enabled_scheduled_jobs(&self) -> Result<Vec<ScheduledJob>> {
+        let jobs = sqlx::query_as!(
+            ScheduledJob,
+            r#"
+            SELECT id, name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at
+            FROM scheduled_jobs
+            WHERE enabled = true
+            ORDER BY id ASC
+            "#
+        )
+        .fetch_all(&self.pool)
+        .await
+        .with_context(|| "failed to fetch enabled scheduled jobs")?;
+
+        Ok(jobs)
+    }
+
+    /// Fetches all scheduled jobs for a specific chat/thread.
+    async fn get_scheduled_jobs_for_chat(
+        &self,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+    ) -> Result<Vec<ScheduledJob>> {
+        let jobs = match message_thread_id {
+            Some(thread_id) => {
+                sqlx::query_as!(
+                    ScheduledJob,
+                    r#"
+                    SELECT id, name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at
+                    FROM scheduled_jobs
+                    WHERE telegram_chat_id = $1 AND message_thread_id = $2
+                    ORDER BY name ASC
+                    "#,
+                    telegram_chat_id,
+                    thread_id
+                )
+                .fetch_all(&self.pool)
+                .await
+                .with_context(|| format!("failed to fetch scheduled jobs for chat {telegram_chat_id} thread {thread_id}"))?
+            }
+            None => {
+                sqlx::query_as!(
+                    ScheduledJob,
+                    r#"
+                    SELECT id, name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at
+                    FROM scheduled_jobs
+                    WHERE telegram_chat_id = $1 AND message_thread_id IS NULL
+                    ORDER BY name ASC
+                    "#,
+                    telegram_chat_id
+                )
+                .fetch_all(&self.pool)
+                .await
+                .with_context(|| format!("failed to fetch scheduled jobs for chat {telegram_chat_id}"))?
+            }
+        };
+
+        Ok(jobs)
+    }
+
+    /// Creates a new scheduled job.
+    async fn create_scheduled_job(
+        &self,
+        name: &str,
+        cron_schedule: &str,
+        prompt: &str,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+    ) -> Result<i32> {
+        let result = sqlx::query!(
+            r#"
+            INSERT INTO scheduled_jobs (name, cron_schedule, prompt, telegram_chat_id, message_thread_id, enabled, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, true, NOW(), NOW())
+            RETURNING id
+            "#,
+            name,
+            cron_schedule,
+            prompt,
+            telegram_chat_id,
+            message_thread_id
+        )
+        .fetch_one(&self.pool)
+        .await
+        .with_context(|| format!("failed to create scheduled job '{name}'"))?;
+
+        Ok(result.id)
+    }
+
+    /// Deletes a scheduled job by name for a specific chat/thread.
+    /// Returns true if a job was deleted, false if no matching job was found.
+    async fn delete_scheduled_job_by_name(
+        &self,
+        name: &str,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+    ) -> Result<bool> {
+        let result = match message_thread_id {
+            Some(thread_id) => sqlx::query!(
+                r#"
+                    DELETE FROM scheduled_jobs
+                    WHERE name = $1 AND telegram_chat_id = $2 AND message_thread_id = $3
+                    "#,
+                name,
+                telegram_chat_id,
+                thread_id
+            )
+            .execute(&self.pool)
+            .await
+            .with_context(|| format!("failed to delete scheduled job '{name}'"))?,
+            None => sqlx::query!(
+                r#"
+                    DELETE FROM scheduled_jobs
+                    WHERE name = $1 AND telegram_chat_id = $2 AND message_thread_id IS NULL
+                    "#,
+                name,
+                telegram_chat_id
+            )
+            .execute(&self.pool)
+            .await
+            .with_context(|| format!("failed to delete scheduled job '{name}'"))?,
+        };
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Sets the enabled status of a scheduled job by name for a specific chat/thread.
+    /// Returns true if a job was updated, false if no matching job was found.
+    async fn set_scheduled_job_enabled(
+        &self,
+        name: &str,
+        telegram_chat_id: i64,
+        message_thread_id: Option<i64>,
+        enabled: bool,
+    ) -> Result<bool> {
+        let result = match message_thread_id {
+            Some(thread_id) => sqlx::query!(
+                r#"
+                    UPDATE scheduled_jobs
+                    SET enabled = $1, updated_at = NOW()
+                    WHERE name = $2 AND telegram_chat_id = $3 AND message_thread_id = $4
+                    "#,
+                enabled,
+                name,
+                telegram_chat_id,
+                thread_id
+            )
+            .execute(&self.pool)
+            .await
+            .with_context(|| format!("failed to update scheduled job '{name}'"))?,
+            None => sqlx::query!(
+                r#"
+                    UPDATE scheduled_jobs
+                    SET enabled = $1, updated_at = NOW()
+                    WHERE name = $2 AND telegram_chat_id = $3 AND message_thread_id IS NULL
+                    "#,
+                enabled,
+                name,
+                telegram_chat_id
+            )
+            .execute(&self.pool)
+            .await
+            .with_context(|| format!("failed to update scheduled job '{name}'"))?,
+        };
+
+        Ok(result.rows_affected() > 0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod env;
 pub mod key_value_store;
 pub mod log;
 pub mod openai_api;
+pub mod scheduler;
 pub mod telegram;
 
 pub use bot::r#loop::{run_bot_loop, TELEGRAM_API_URL};

--- a/src/scheduler/executor.rs
+++ b/src/scheduler/executor.rs
@@ -1,0 +1,73 @@
+use crate::ai_interaction::tools::beacon_slot_check::BeaconNode;
+use crate::ai_interaction::{
+    drive_ai_conversation, get_current_model_id, AiConversationOutcome, HandlerContext,
+};
+use crate::db::Db;
+use crate::scheduler::types::ScheduledJob;
+use crate::telegram;
+use anyhow::Result;
+use tracing::info;
+
+use super::SchedulerContext;
+
+/// Execute a scheduled job by sending its prompt to OpenAI and delivering the response to Telegram.
+pub async fn execute_scheduled_job<D, B>(
+    job: &ScheduledJob,
+    ctx: &SchedulerContext<D, B>,
+) -> Result<()>
+where
+    D: Db + Clone,
+    B: BeaconNode + Clone,
+{
+    info!(job_name = %job.name, job_id = job.id, "executing scheduled job");
+
+    // Build handler context with full tool access (same as regular messages)
+    let handler_ctx = HandlerContext {
+        db: ctx.db.clone(),
+        http_client: ctx.http_client.clone(),
+        bot_db_id: ctx.bot_db_id,
+        openai_api_key: ctx.openai_api_key.clone(),
+        beacon_node: ctx.beacon_node.clone(),
+        relay_circuit_breaker: ctx.relay_circuit_breaker.clone(),
+        schema_fetcher: ctx.schema_fetcher.clone(),
+        // Pass chat context so scheduled jobs can manage their own jobs if needed
+        current_telegram_chat_id: Some(job.telegram_chat_id),
+        current_message_thread_id: job.message_thread_id,
+    };
+
+    // Use existing AI conversation driver with full tools
+    let current_model = get_current_model_id().await;
+    let outcome = drive_ai_conversation(
+        &handler_ctx,
+        &job.prompt,
+        None, // No previous_response_id for scheduled tasks
+        &current_model,
+        false, // No admin session for scheduled tasks
+    )
+    .await?;
+
+    // Extract response text from outcome
+    let response_text = match outcome {
+        AiConversationOutcome::TextMessage(text, _response_id) => text,
+        AiConversationOutcome::ResetConversation(text, _) => text,
+        AiConversationOutcome::ChangeModel(text, _, _) => text,
+        AiConversationOutcome::ChangeVerbosity(text, _, _) => text,
+        AiConversationOutcome::ChangeReasoningEffort(text, _, _) => text,
+        AiConversationOutcome::EndAdminSession(text, _) => text,
+    };
+
+    // Send to Telegram
+    telegram::send_message(
+        &ctx.http_client,
+        &ctx.api_base_url,
+        &ctx.bot_token,
+        job.telegram_chat_id,
+        &response_text,
+        job.message_thread_id,
+        Some("Markdown"),
+    )
+    .await?;
+
+    info!(job_name = %job.name, job_id = job.id, "scheduled job executed successfully");
+    Ok(())
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,0 +1,44 @@
+pub mod executor;
+pub mod service;
+pub mod types;
+
+use crate::ai_interaction::tools::beacon_slot_check::BeaconNode;
+use crate::ai_interaction::tools::db_schema::LiveSchemaFetcher;
+use crate::ai_interaction::tools::relay_circuit_breaker::RelayCircuitBreaker;
+use crate::bot::BotContext;
+use crate::db::Db;
+use reqwest::Client as ReqwestClient;
+
+/// Context required by the scheduler to execute jobs.
+/// Contains all dependencies needed to call AI and send Telegram messages.
+#[derive(Clone)]
+pub struct SchedulerContext<D: Db, B: BeaconNode> {
+    pub db: D,
+    pub http_client: ReqwestClient,
+    pub api_base_url: String,
+    pub bot_token: String,
+    pub bot_db_id: i32,
+    pub openai_api_key: String,
+    pub schema_fetcher: LiveSchemaFetcher,
+    pub beacon_node: B,
+    pub relay_circuit_breaker: RelayCircuitBreaker,
+}
+
+impl<D: Db + Clone>
+    SchedulerContext<D, crate::ai_interaction::tools::beacon_slot_check::BeaconNodeHttp>
+{
+    /// Create a SchedulerContext from an existing BotContext
+    pub fn from_bot_context(ctx: &BotContext<D>) -> Self {
+        Self {
+            db: ctx.db.clone(),
+            http_client: ctx.http_client.clone(),
+            api_base_url: ctx.api_base_url.clone(),
+            bot_token: ctx.bot_token.clone(),
+            bot_db_id: ctx.bot_db_id,
+            openai_api_key: ctx.openai_api_key.clone(),
+            schema_fetcher: ctx.schema_fetcher.clone(),
+            beacon_node: ctx.beacon_node.clone(),
+            relay_circuit_breaker: ctx.relay_circuit_breaker.clone(),
+        }
+    }
+}

--- a/src/scheduler/service.rs
+++ b/src/scheduler/service.rs
@@ -1,0 +1,151 @@
+use crate::ai_interaction::tools::beacon_slot_check::BeaconNode;
+use crate::db::Db;
+use crate::scheduler::executor::execute_scheduled_job;
+use crate::scheduler::types::ScheduledJob;
+use crate::scheduler::SchedulerContext;
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::time::Duration;
+use tracing::{error, info, warn};
+
+/// Tracks when a job was last executed
+struct JobState {
+    job: ScheduledJob,
+    last_run: Option<DateTime<Utc>>,
+}
+
+/// Runs the scheduler service that manages and executes scheduled jobs.
+/// Uses a polling approach to check cron schedules and execute jobs.
+pub async fn run_scheduler<D, B>(ctx: SchedulerContext<D, B>) -> Result<()>
+where
+    D: Db + Clone + Send + Sync + 'static,
+    B: BeaconNode + Clone + Send + Sync + 'static,
+{
+    info!("starting scheduler service");
+
+    // Track job states
+    let mut job_states: HashMap<i32, JobState> = HashMap::new();
+
+    // Initial job load
+    if let Err(e) = reload_jobs(&ctx.db, &mut job_states).await {
+        error!(error = %e, "failed initial job load");
+    }
+
+    info!(
+        job_count = job_states.len(),
+        "scheduler started, checking jobs every minute"
+    );
+
+    let mut reload_counter = 0u32;
+
+    // Main scheduler loop - check every minute
+    loop {
+        let now = Utc::now();
+
+        // Check each job to see if it should run
+        for state in job_states.values_mut() {
+            if should_run_job(&state.job, state.last_run, now) {
+                info!(
+                    job_name = %state.job.name,
+                    job_id = state.job.id,
+                    "executing scheduled job"
+                );
+
+                // Execute the job
+                if let Err(e) = execute_scheduled_job(&state.job, &ctx).await {
+                    error!(
+                        job_name = %state.job.name,
+                        error = %e,
+                        "scheduled job execution failed"
+                    );
+                }
+
+                // Update last run time regardless of success/failure to prevent retry loops
+                state.last_run = Some(now);
+            }
+        }
+
+        // Wait for next minute
+        tokio::time::sleep(Duration::from_secs(60)).await;
+
+        // Reload jobs from database every 5 minutes
+        reload_counter += 1;
+        if reload_counter >= 5 {
+            reload_counter = 0;
+            if let Err(e) = reload_jobs(&ctx.db, &mut job_states).await {
+                error!(error = %e, "failed to reload scheduled jobs");
+            }
+        }
+    }
+}
+
+/// Reload jobs from database, preserving last_run times for existing jobs
+async fn reload_jobs<D: Db>(db: &D, job_states: &mut HashMap<i32, JobState>) -> Result<()> {
+    info!("reloading scheduled jobs from database");
+
+    let enabled_jobs = db.get_enabled_scheduled_jobs().await?;
+    let enabled_job_ids: std::collections::HashSet<i32> =
+        enabled_jobs.iter().map(|j| j.id).collect();
+
+    // Remove jobs that are no longer enabled
+    job_states.retain(|id, _| enabled_job_ids.contains(id));
+
+    // Add or update jobs
+    for job in enabled_jobs {
+        if let Some(state) = job_states.get_mut(&job.id) {
+            // Update job definition but keep last_run
+            state.job = job;
+        } else {
+            // New job
+            info!(
+                job_id = job.id,
+                job_name = %job.name,
+                cron = %job.cron_schedule,
+                "registered new scheduled job"
+            );
+            job_states.insert(
+                job.id,
+                JobState {
+                    job,
+                    last_run: None,
+                },
+            );
+        }
+    }
+
+    info!(
+        registered_count = job_states.len(),
+        "scheduled jobs reload complete"
+    );
+    Ok(())
+}
+
+/// Check if a job should run based on its cron schedule
+fn should_run_job(job: &ScheduledJob, last_run: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    // Parse the cron schedule
+    let schedule = match croner::Cron::new(&job.cron_schedule).parse() {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                job_name = %job.name,
+                cron = %job.cron_schedule,
+                error = %e,
+                "failed to parse cron schedule"
+            );
+            return false;
+        }
+    };
+
+    // Find the next scheduled time after last_run (or epoch if never run)
+    let after = last_run.unwrap_or_else(|| DateTime::from_timestamp(0, 0).unwrap());
+
+    // Get the next occurrence after the last run
+    match schedule.find_next_occurrence(&after, false) {
+        Ok(next_run) => {
+            // If the next scheduled time is in the past (or now), we should run
+            next_run <= now
+        }
+        Err(_) => false,
+    }
+}

--- a/src/scheduler/types.rs
+++ b/src/scheduler/types.rs
@@ -1,0 +1,15 @@
+use chrono::{DateTime, Utc};
+
+/// A scheduled job stored in the database
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ScheduledJob {
+    pub id: i32,
+    pub name: String,
+    pub cron_schedule: String,
+    pub prompt: String,
+    pub telegram_chat_id: i64,
+    pub message_thread_id: Option<i64>,
+    pub enabled: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}


### PR DESCRIPTION
## Summary

Adds cron-based scheduled tasks to Lexi, allowing automated prompts to run on a schedule and send responses to Telegram channels.

### Features

**Scheduler Service**
- Polling-based scheduler checks job schedules every minute
- Jobs stored in database with cron expressions (e.g., `0 9 * * *` for daily at 9am UTC)
- Full tool access for scheduled prompts (relay status, beacon checks, DB queries, etc.)
- Automatic job configuration reload every 5 minutes

**Management Tool**
- New `scheduled_jobs` AI tool lets users manage jobs via natural conversation
- Commands: `list`, `add`, `delete`, `enable`, `disable`
- Jobs scoped to the current chat/thread - users can only manage their own
- No admin code required

### Example Messages

**Add a job:**
```
@lexi schedule a job called "morning_check" to run daily at 9am with the prompt "Check the relay status and summarize any issues"
```

**List jobs:**
```
@lexi what scheduled jobs do we have?
```

**Disable/Enable a job:**
```
@lexi disable the scheduled job "morning_check"
@lexi enable the "morning_check" scheduled job
```

**Delete a job:**
```
@lexi delete the scheduled job called "morning_check"
```

Lexi interprets natural language and converts schedule descriptions (like "daily at 9am", "every hour", "weekdays at noon") to cron expressions.

### Changes

- New `src/scheduler/` module (types, executor, service)
- New `src/ai_interaction/tools/scheduled_jobs.rs` tool
- Migration for `scheduled_jobs` table
- Added chat context to `HandlerContext` for tool scoping
- 11 new tests for the scheduled jobs tool (140 total tests passing)

---
🤖 Generated with [Claude Code](https://claude.ai/code)
